### PR TITLE
Add buttons for choosing scene print revision number

### DIFF
--- a/TrainingMLImageClassifier/Logic/ImageTrainer.swift
+++ b/TrainingMLImageClassifier/Logic/ImageTrainer.swift
@@ -10,6 +10,8 @@ class ImageTrainer: NSObject {
     let validationAccuracy: Double
   }
 
+  let scenePrintRevisions: [Int]
+
   var result: AnyPublisher<TrainingResult, Never> {
     self.resultSubject.eraseToAnyPublisher()
   }
@@ -21,6 +23,12 @@ class ImageTrainer: NSObject {
   private var trainingStartedDate: Date? = nil
 
   override init() {
+    if #available(iOS 17.0, *) {
+      self.scenePrintRevisions = [1, 2]
+    } else {
+      self.scenePrintRevisions = [1]
+    }
+
     super.init()
   }
   func cancel() {
@@ -30,13 +38,13 @@ class ImageTrainer: NSObject {
 
     job.cancel()
   }
-  func train(from trainingDataDirectory: URL, to mlmodelFileURL: URL) {
+  func train(from trainingDataDirectory: URL, to mlmodelFileURL: URL, scenePrintRevision: Int = 1) {
     let parameters = MLImageClassifier.ModelParameters(
       validation: .split(strategy: .automatic),
       maxIterations: 50,
       augmentation: [],
       algorithm: .transferLearning(
-        featureExtractor: .scenePrint(revision: nil),
+        featureExtractor: .scenePrint(revision: scenePrintRevision),
         classifier: .logisticRegressor
       )
     )

--- a/TrainingMLImageClassifier/Views/TrainingView.swift
+++ b/TrainingMLImageClassifier/Views/TrainingView.swift
@@ -15,6 +15,8 @@ struct TrainingView: View {
 
   @State var trainingState: TrainingState = .ready
 
+  @State var scenePrintRevision = 1
+
   @State var imagesCount = 0
   @State var totalImagesCount = 0
   @State var imageGenerationProgress: Double = 0.0
@@ -30,6 +32,23 @@ struct TrainingView: View {
         .font(.title)
         .padding()
       if self.trainingState == .ready {
+        Text("Choose scene print: ")
+          .padding()
+        HStack {
+          ForEach(self.imageTrainer.scenePrintRevisions, id: \.self) { revision in
+            Button(action: {
+              self.scenePrintRevision = revision
+            }) {
+              Text("Revision \(revision)")
+                .padding()
+                .foregroundColor(.white)
+                .background(Color.indigo)
+            }
+            .opacity(self.scenePrintRevision == revision ? 1.0 : 0.75)
+            .accessibilityAddTraits(self.scenePrintRevision == revision ? .isSelected : .init())
+          }
+        }
+        .padding()
         Button(action: {
           self.start()
         }) {
@@ -89,7 +108,8 @@ struct TrainingView: View {
 
           self.imageTrainer.train(
             from: self.appConstants.trainingDataDirectory,
-            to: self.appConstants.mlmodelFile
+            to: self.appConstants.mlmodelFile,
+            scenePrintRevision: self.scenePrintRevision
           )
         }
       }


### PR DESCRIPTION
## Summary

For avoiding the error mentioned in issue #1, I've added the buttons for choosing scene print revision number. The users can choose the revision before starting the model training.